### PR TITLE
Remove unneeded `FALL_THROUGH`

### DIFF
--- a/src/ace_demux.sv
+++ b/src/ace_demux.sv
@@ -89,7 +89,7 @@ module ace_demux #(
         assign b_idx_in = i_axi_demux.i_demux_simple.genblk1.b_idx; // TODO: add idx as port in demux
 
         fifo_v3 #(
-            .FALL_THROUGH (!SpillB),
+            .FALL_THROUGH (1'b0),
             .DEPTH        (MaxTrans),
             .dtype        (select_t)
         ) i_b_fifo (
@@ -109,7 +109,7 @@ module ace_demux #(
         assign r_idx_in = i_axi_demux.i_demux_simple.genblk1.r_idx; // TODO: add idx as port in demux
 
         fifo_v3 #(
-            .FALL_THROUGH (!SpillR),
+            .FALL_THROUGH (1'b0),
             .DEPTH        (MaxTrans),
             .dtype        (select_t)
         ) i_r_fifo (

--- a/src/ace_mux.sv
+++ b/src/ace_mux.sv
@@ -97,7 +97,7 @@ module ace_mux #(
         assign b_idx_in = mst_resp.b.id[SlvAxiIDWidth+:MstIdxBits];
 
         fifo_v3 #(
-            .FALL_THROUGH (!SpillB),
+            .FALL_THROUGH (1'b0),
             .DEPTH        (MaxRespTrans),
             .dtype        (switch_id_t)
         ) i_b_fifo (
@@ -117,7 +117,7 @@ module ace_mux #(
         assign r_idx_in = mst_resp.r.id[SlvAxiIDWidth+:MstIdxBits];
 
         fifo_v3 #(
-            .FALL_THROUGH (!SpillR),
+            .FALL_THROUGH (1'b0),
             .DEPTH        (MaxRespTrans),
             .dtype        (switch_id_t)
         ) i_r_fifo (


### PR DESCRIPTION
Since `WACK` and `RACK` are generated with at least one cycle of delay from the observed response handshake, there is no need to support `FALL_THROUGH=1`.