### PR TITLE
Overhaul conflict management logic

### DIFF
--- a/src/ccu/ace_ccu_conflict_manager.sv
+++ b/src/ccu/ace_ccu_conflict_manager.sv
@@ -3,221 +3,51 @@ module ace_ccu_conflict_manager #(
     parameter int unsigned NoRespPorts   = 0,
     parameter int unsigned MaxRespTrans  = 0,
     parameter int unsigned MaxSnoopTrans = 0,
-    parameter int unsigned LupAddrBase   = 0,
-    parameter int unsigned LupAddrWidth  = 0,
+    parameter int unsigned CmIdxBase     = 0,
+    parameter int unsigned CmIdxWidth    = 0,
 
-    localparam type addr_t               = logic [AxiAddrWidth-1:0],
-    localparam type lup_addr_t           = logic [LupAddrWidth-1:0]
+    localparam type cm_idx_t             = logic [CmIdxWidth-1:0]
 ) (
     input  logic                    clk_i,
     input  logic                    rst_ni,
 
-    input  logic  [NoRespPorts-1:0] x_valid_i,
-    output logic  [NoRespPorts-1:0] x_ready_o,
-    input  addr_t [NoRespPorts-1:0] x_addr_i,
-    input  logic  [NoRespPorts-1:0] x_lasts_i,
-    output logic  [NoRespPorts-1:0] x_valid_o,
-    input  logic  [NoRespPorts-1:0] x_ready_i,
-
-    input  logic  [NoRespPorts-1:0] x_ack_i,
-
-    input  logic                    snoop_valid_i,
-    output logic                    snoop_ready_o,
-    input  logic                    snoop_clr_i,
-    input  addr_t                   snoop_addr_i,
-    output logic                    snoop_valid_o,
-    input  logic                    snoop_ready_i
+    input  logic                      cm_snoop_req_i,
+    input  cm_idx_t                   cm_snoop_addr_i,
+    output logic                      cm_snoop_stall_o,
+    input  logic    [NoRespPorts-1:0] cm_x_req_i,
+    input  cm_idx_t [NoRespPorts-1:0] cm_x_addr_i
 );
 
-    logic [NoRespPorts-1:0] x_match, snoop_match;
-    logic [NoRespPorts-1:0] addr_equal, addr_conflict;
-    logic [NoRespPorts-1:0] snoop_valid, snoop_ready;
-    logic [NoRespPorts-1:0] snoop_arb_valid, snoop_arb_ready;
+localparam int unsigned NumEntries = 2**CmIdxWidth;
 
-    logic [NoRespPorts-1:0] sel_q, sel_d, sel;
-    logic                   snoop_lock_q, snoop_lock_d;
+logic  [NumEntries-1:0]  valid_q, valid_d;
+logic  [NumEntries-1:0]  set, clear;
 
-    lup_addr_t                   snoop_addr;
-    lup_addr_t [NoRespPorts-1:0] x_addr;
+assign valid_d = ~clear & (set | valid_q);
 
+assign cm_snoop_stall_o = valid_q[cm_snoop_addr_i];
 
-    for (genvar i = 0; i < NoRespPorts; i++) begin : gen_resp_path
-        logic [1:0] arb_valids, arb_readies, arb_masks;
-        logic       arb_valid, arb_ready;
-        logic       arb_sel;
-        logic       conflict_no_sel;
+always_comb begin
+    clear = '0;
 
-        logic fifo_push, fifo_full;
-        logic x_lock_q, x_lock_d;
-
-        logic x_valid_out, x_ready_in;
-
-        assign x_addr[i] = x_addr_i[i][LupAddrBase+:LupAddrWidth];
-
-        assign addr_equal[i]    = snoop_addr == x_addr[i];
-        assign addr_conflict[i] = addr_equal[i] && x_valid_i[i];
-        assign conflict_no_sel  = addr_conflict[i] && !sel_q[i] && snoop_lock_q;
-
-        assign arb_masks = ~{fifo_full || conflict_no_sel, x_lock_q};
-
-        assign arb_valids = {x_valid_i[i], snoop_valid[i]}  & arb_masks;
-        assign {x_ready_o[i], snoop_ready[i]} = arb_readies & arb_masks;
-
-        rr_arb_tree #(
-            .NumIn      (2),
-            .DataType   (logic),
-            .ExtPrio    (1'b0),
-            .AxiVldRdy  (1'b1),
-            .LockIn     (1'b1)
-        ) i_arb (
-            .clk_i,
-            .rst_ni,
-            .flush_i ('0),
-            .rr_i    ('0),
-            .req_i   (arb_valids),
-            .gnt_o   (arb_readies),
-            .data_i  ('0),
-            .req_o   (arb_valid),
-            .gnt_i   (arb_ready),
-            .data_o  (),
-            .idx_o   (arb_sel)
-        );
-
-        stream_demux #(
-            .N_OUP (2)
-        ) i_arb_demux (
-            .inp_valid_i (arb_valid),
-            .inp_ready_o (arb_ready),
-            .oup_sel_i   (arb_sel),
-            .oup_valid_o ({x_valid_out, snoop_arb_valid[i]}),
-            .oup_ready_i ({x_ready_in, snoop_arb_ready[i]})
-        );
-
-        assign x_valid_o[i] = x_match[i] ? 1'b0 : x_valid_out;
-        assign x_ready_in   = x_match[i] ? 1'b0 : x_ready_i[i];
-
-        assign fifo_push = x_valid_o[i] && !x_lock_q;
-
-        assign x_lock_d = !(x_ready_i[i] && x_lasts_i[i] && x_valid_o[i]) &&
-                           (x_valid_o[i] || x_lock_q);
-
-        always_ff @(posedge clk_i or negedge rst_ni) begin
-            if (!rst_ni) x_lock_q <= 1'b0;
-            else         x_lock_q <= x_lock_d;
-        end
-
-        lookup_fifo #(
-            .DEPTH        (MaxRespTrans),
-            .LOOKUP_PORTS (1),
-            .dtype        (lup_addr_t)
-        ) i_addr_fifo (
-            .clk_i,
-            .rst_ni,
-            .push_i         (fifo_push),
-            .full_o         (fifo_full),
-            .data_i         (x_addr[i]),
-            .pop_i          (x_ack_i[i]),
-            .empty_o        (),
-            .data_o         (),
-            .lookup_data_i  (snoop_addr),
-            .lookup_match_o (snoop_match[i])
-        );
+    for (int unsigned p = 0; p < NoRespPorts; p++) begin
+        if (cm_x_req_i[p])
+            clear[cm_x_addr_i[p]] = 1'b1;
     end
+end
 
+always_comb begin
+    set = '0;
+    if (cm_snoop_req_i)
+        set[cm_snoop_addr_i] = 1'b1;
+end
 
-    generate
-    begin : gen_snoop_path
-        logic snoop_fork_valid, snoop_fork_ready;
-        logic snoop_valid_in, snoop_ready_out;
-        logic snoop_valid_out, snoop_ready_in;
-        logic fifo_full, fifo_push;
-
-        assign snoop_addr = snoop_addr_i[LupAddrBase+:LupAddrWidth];
-
-        always_ff @(posedge clk_i or negedge rst_ni) begin
-            if (!rst_ni) begin
-                sel_q  <= '0;
-                snoop_lock_q <= '0;
-            end else begin
-                sel_q  <= sel_d;
-                snoop_lock_q <= snoop_lock_d;
-            end
-        end
-
-        assign snoop_valid_in = fifo_full ? 1'b0 : snoop_valid_i;
-        assign snoop_ready_o  = fifo_full ? 1'b0 : snoop_ready_out;
-
-        assign sel = snoop_lock_q ? sel_q : addr_conflict;
-
-        always_comb begin
-            snoop_fork_valid = 1'b0;
-
-            snoop_lock_d = snoop_lock_q;
-            sel_d  = sel_q;
-
-            case (snoop_lock_q)
-                1'b0: begin
-                    if (!fifo_full && snoop_valid_i && |addr_conflict) begin
-                        snoop_fork_valid = 1'b1;
-                        sel_d            = addr_conflict;
-                        if (!snoop_fork_ready)
-                            snoop_lock_d = 1'b1;
-                    end
-                end
-                1'b1: begin
-                    snoop_fork_valid = 1'b1;
-                    if (snoop_fork_ready) begin
-                        snoop_lock_d = 1'b0;
-                    end
-                end
-            endcase
-        end
-
-        stream_fork_dynamic #(
-            .N_OUP (NoRespPorts)
-        ) i_snoop_fork (
-            .clk_i,
-            .rst_ni,
-            .valid_i     (snoop_fork_valid),
-            .ready_o     (snoop_fork_ready),
-            .sel_i       (sel),
-            .sel_valid_i (snoop_fork_valid),
-            .sel_ready_o (),
-            .valid_o     (snoop_valid),
-            .ready_i     (snoop_ready)
-        );
-
-        stream_join_dynamic #(
-            .N_INP (NoRespPorts+1)
-        ) i_snoop_join (
-            .inp_valid_i ({snoop_arb_valid, snoop_valid_in}),
-            .inp_ready_o ({snoop_arb_ready, snoop_ready_out}),
-            .sel_i       ({sel, 1'b1}),
-            .oup_valid_o (snoop_valid_out),
-            .oup_ready_i (snoop_ready_in)
-        );
-
-        assign snoop_valid_o  = |snoop_match ? 1'b0 : snoop_valid_out;
-        assign snoop_ready_in = |snoop_match ? 1'b0 : snoop_ready_i;
-
-        assign fifo_push = snoop_valid_o && snoop_ready_i;
-
-        lookup_fifo #(
-            .DEPTH        (MaxSnoopTrans),
-            .LOOKUP_PORTS (NoRespPorts),
-            .dtype        (lup_addr_t)
-        ) i_addr_fifo (
-            .clk_i,
-            .rst_ni,
-            .push_i         (fifo_push),
-            .full_o         (fifo_full),
-            .data_i         (snoop_addr),
-            .pop_i          (snoop_clr_i),
-            .empty_o        (),
-            .data_o         (),
-            .lookup_data_i  (x_addr),
-            .lookup_match_o (x_match)
-        );
+always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+        valid_q <= '0;
+    end else begin
+        valid_q <= valid_d;
     end
-    endgenerate;
+end
+
 endmodule

--- a/src/ccu/ace_ccu_conflict_manager.sv
+++ b/src/ccu/ace_ccu_conflict_manager.sv
@@ -3,50 +3,122 @@ module ace_ccu_conflict_manager #(
     parameter int unsigned NoRespPorts   = 0,
     parameter int unsigned MaxRespTrans  = 0,
     parameter int unsigned MaxSnoopTrans = 0,
-    parameter int unsigned CmIdxBase     = 0,
-    parameter int unsigned CmIdxWidth    = 0,
+    parameter int unsigned CmAddrWidth   = 0,
 
-    localparam type cm_idx_t             = logic [CmIdxWidth-1:0]
+    localparam type cm_addr_t            = logic [CmAddrWidth-1:0]
 ) (
-    input  logic                    clk_i,
-    input  logic                    rst_ni,
-
-    input  logic                      cm_snoop_req_i,
-    input  cm_idx_t                   cm_snoop_addr_i,
-    output logic                      cm_snoop_stall_o,
-    input  logic    [NoRespPorts-1:0] cm_x_req_i,
-    input  cm_idx_t [NoRespPorts-1:0] cm_x_addr_i
+    input  logic                       clk_i,
+    input  logic                       rst_ni,
+    input  logic                       cm_snoop_valid_i,
+    input  logic                       cm_snoop_ready_i,
+    input  cm_addr_t                   cm_snoop_addr_i,
+    output logic                       cm_snoop_stall_o,
+    input  logic     [NoRespPorts-1:0] cm_x_req_i,
+    input  cm_addr_t [NoRespPorts-1:0] cm_x_addr_i
 );
 
-localparam int unsigned NumEntries = 2**CmIdxWidth;
+localparam int unsigned IdxWidth   = 4;
+localparam int unsigned NumWays    = 2;
+localparam int unsigned NumSets    = 2**IdxWidth;
+localparam int unsigned TagWidth   = CmAddrWidth - IdxWidth;
 
-logic  [NumEntries-1:0]  valid_q, valid_d;
-logic  [NumEntries-1:0]  set, clear;
+typedef logic [TagWidth-1:0] tag_t;
+typedef logic [IdxWidth-1:0] idx_t;
 
-assign valid_d = ~clear & (set | valid_q);
+typedef struct packed {
+    tag_t tag;
+    idx_t idx;
+} addr_t;
 
-assign cm_snoop_stall_o = valid_q[cm_snoop_addr_i];
+typedef struct packed {
+    tag_t tag;
+    logic valid;
+} entry_t;
+
+entry_t [NumWays-1:0][NumSets-1:0]         entries_q, entries_d;
+logic   [NumWays-1:0][NumSets-1:0]         set, clear;
+logic   [NumSets-1:0][$clog2(NumWays)-1:0] lowest_free;
+logic   [NumSets-1:0]                      any_free;
+logic                                      tag_hit;
+
+addr_t                   snoop_addr;
+addr_t [NoRespPorts-1:0] x_addr;
+
+assign snoop_addr = cm_snoop_addr_i;
+
+for (genvar r = 0; r < NoRespPorts; r++)
+    assign x_addr[r] = cm_x_addr_i[r];
+
+for (genvar s = 0; s < NumSets; s++) begin
+    always_comb begin
+        lowest_free[s] = '0;
+        any_free   [s] = '0;
+        for (int unsigned w = 0; w < NumWays; w++) begin
+            if (!entries_q[w][s].valid) begin
+                lowest_free[s] = w;
+                any_free   [s] = 1'b1;
+                break;
+            end
+        end
+    end
+end
+
+always_comb begin
+    entries_d = entries_q;
+
+    for (int unsigned w = 0; w < NumWays; w++) begin
+        for (int unsigned s = 0; s < NumSets; s++) begin
+            if (clear[w][s]) begin
+                entries_d[w][s].valid = 1'b0;
+            end else if (set[w][s]) begin
+                entries_d[w][s].valid = 1'b1;
+                entries_d[w][s].tag   = snoop_addr.tag;
+            end
+        end
+    end
+end
+
+assign cm_snoop_stall_o = !any_free[snoop_addr.idx] || tag_hit;
+
+always_comb begin
+    tag_hit = 1'b0;
+
+    if (cm_snoop_valid_i) begin
+        for (int unsigned w = 0; w < NumWays; w++) begin
+            if (entries_q[w][snoop_addr.idx].valid &&
+                entries_q[w][snoop_addr.idx].tag == snoop_addr.tag) begin
+                tag_hit = 1'b1;
+                break;
+            end
+        end
+    end
+end
 
 always_comb begin
     clear = '0;
 
-    for (int unsigned p = 0; p < NoRespPorts; p++) begin
-        if (cm_x_req_i[p])
-            clear[cm_x_addr_i[p]] = 1'b1;
+    for (int unsigned r = 0; r < NoRespPorts; r++) begin
+        for (int unsigned w = 0; w < NumWays; w++) begin
+            if (entries_q[w][x_addr[r].idx].valid &&
+                entries_q[w][x_addr[r].idx].tag == x_addr[r].tag) begin
+                clear[w][x_addr[r].idx] = 1'b1;
+            end
+        end
     end
 end
 
 always_comb begin
     set = '0;
-    if (cm_snoop_req_i)
-        set[cm_snoop_addr_i] = 1'b1;
+
+    if (cm_snoop_valid_i && cm_snoop_ready_i && !cm_snoop_stall_o)
+        set[lowest_free[snoop_addr.idx]][snoop_addr.idx] = 1'b1;
 end
 
 always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-        valid_q <= '0;
+        entries_q <= '0;
     end else begin
-        valid_q <= valid_d;
+        entries_q <= entries_d;
     end
 end
 

--- a/src/ccu/ace_ccu_master_path.sv
+++ b/src/ccu/ace_ccu_master_path.sv
@@ -11,8 +11,8 @@ module ace_ccu_master_path import ace_pkg::*;
   parameter int unsigned NoSlvPorts      = 0,
   parameter int unsigned NoSlvPerGroup   = 0,
   parameter int unsigned DcacheLineWidth = 0,
-  parameter int unsigned CmIdxBase       = 0,
-  parameter int unsigned CmIdxWidth      = 0,
+  parameter int unsigned CmAddrBase      = 0,
+  parameter int unsigned CmAddrWidth     = 0,
   parameter bit          ConfCheck       = 0,
   parameter type slv_ar_chan_t           = logic,
   parameter type slv_aw_chan_t           = logic,
@@ -38,7 +38,7 @@ module ace_ccu_master_path import ace_pkg::*;
   localparam int unsigned NoGroups             = NoSlvPorts / NoSlvPerGroup,
   localparam int unsigned NoSnoopPortsPerGroup = 2,
   localparam int unsigned NoSnoopPorts         = NoSnoopPortsPerGroup * NoGroups,
-  localparam type cm_idx_t                     = logic [CmIdxWidth-1:0]
+  localparam type cm_addr_t                    = logic [CmAddrWidth-1:0]
 ) (
   input  logic                           clk_i,
   input  logic                           rst_ni,
@@ -52,7 +52,7 @@ module ace_ccu_master_path import ace_pkg::*;
   input  mst_resp_t                      mst_resp_i,
 
   output logic      [2*NoGroups-1:0]     cm_req_o,
-  output cm_idx_t   [2*NoGroups-1:0]     cm_addr_o
+  output cm_addr_t  [2*NoGroups-1:0]     cm_addr_o
 );
 
   typedef logic [AxiAddrWidth -1:0]  addr_t;
@@ -233,12 +233,12 @@ module ace_ccu_master_path import ace_pkg::*;
       .CAPACITY            (8),
       .FULL_BW             (1'b1),
       .CUT_OUP_POP_INP_GNT (1'b1),
-      .data_t              (cm_idx_t)
+      .data_t              (cm_addr_t)
     ) i_w_queue (
       .clk_i,
       .rst_ni,
       .inp_id_i         (ace_snooping_muxed_req.aw.id),
-      .inp_data_i       (ace_snooping_muxed_req.aw.addr[CmIdxBase+:CmIdxWidth]),
+      .inp_data_i       (ace_snooping_muxed_req.aw.addr[CmAddrBase+:CmAddrWidth]),
       .inp_req_i        (aw_queue_valid),
       .inp_gnt_o        (aw_queue_ready),
       .exists_data_i    ('0),
@@ -288,12 +288,12 @@ module ace_ccu_master_path import ace_pkg::*;
       .CAPACITY            (8),
       .FULL_BW             (1'b1),
       .CUT_OUP_POP_INP_GNT (1'b1),
-      .data_t              (cm_idx_t)
+      .data_t              (cm_addr_t)
     ) i_r_queue (
       .clk_i,
       .rst_ni,
       .inp_id_i         (ace_snooping_muxed_req.ar.id),
-      .inp_data_i       (ace_snooping_muxed_req.ar.addr[CmIdxBase+:CmIdxWidth]),
+      .inp_data_i       (ace_snooping_muxed_req.ar.addr[CmAddrBase+:CmAddrWidth]),
       .inp_req_i        (ar_queue_valid),
       .inp_gnt_o        (ar_queue_ready),
       .exists_data_i    ('0),

--- a/src/ccu/ace_ccu_snoop_interconnect.sv
+++ b/src/ccu/ace_ccu_snoop_interconnect.sv
@@ -6,8 +6,8 @@ module ace_ccu_snoop_interconnect import ace_pkg::*; #(
     parameter bit           BufferOupResp = 1,
     parameter bit           BufferInpReq  = 1,
     parameter bit           BufferInpResp = 1,
-    parameter int unsigned  CmIdxWidth    = 0,
-    parameter int unsigned  CmIdxBase     = 0,
+    parameter int unsigned  CmAddrWidth   = 0,
+    parameter int unsigned  CmAddrBase    = 0,
     parameter type          ac_chan_t     = logic,
     parameter type          cr_chan_t     = logic,
     parameter type          cd_chan_t     = logic,
@@ -15,7 +15,7 @@ module ace_ccu_snoop_interconnect import ace_pkg::*; #(
     parameter type          snoop_resp_t  = logic,
 
     localparam type         oup_sel_t     = logic [NumOup-1:0],
-    localparam type         cm_idx_t      = logic [CmIdxWidth-1:0]
+    localparam type         cm_addr_t     = logic [CmAddrWidth-1:0]
 ) (
 
     input  logic                     clk_i,
@@ -27,8 +27,9 @@ module ace_ccu_snoop_interconnect import ace_pkg::*; #(
     output snoop_req_t  [NumOup-1:0] oup_req_o,
     input  snoop_resp_t [NumOup-1:0] oup_resp_i,
 
-    output  logic                    cm_req_o,
-    output  cm_idx_t                 cm_addr_o,
+    output  logic                    cm_valid_o,
+    output  logic                    cm_ready_o,
+    output  cm_addr_t                cm_addr_o,
     input   logic                    cm_stall_i
 );
 
@@ -237,8 +238,9 @@ module ace_ccu_snoop_interconnect import ace_pkg::*; #(
         .ctrl_o          (req_ctrl)
     );
 
-    assign cm_req_o      = ac_valid && oup_ac_ready;
-    assign cm_addr_o     = ac_chan.addr[CmIdxBase+:CmIdxWidth];
+    assign cm_valid_o    = ac_valid;
+    assign cm_ready_o    = oup_ac_ready;
+    assign cm_addr_o     = ac_chan.addr[CmAddrBase+:CmAddrWidth];
     assign ac_ready      = oup_ac_ready && !cm_stall_i;
     assign oup_ac_valid  = ac_valid     && !cm_stall_i;
 

--- a/src/ccu/ace_ccu_snoop_interconnect.sv
+++ b/src/ccu/ace_ccu_snoop_interconnect.sv
@@ -6,9 +6,8 @@ module ace_ccu_snoop_interconnect import ace_pkg::*; #(
     parameter bit           BufferOupResp = 1,
     parameter bit           BufferInpReq  = 1,
     parameter bit           BufferInpResp = 1,
-    parameter int unsigned  LupAddrBase   = 0,
-    parameter int unsigned  LupAddrWidth  = 0,
-    parameter bit           ConfCheck     = 1,
+    parameter int unsigned  CmIdxWidth    = 0,
+    parameter int unsigned  CmIdxBase     = 0,
     parameter type          ac_chan_t     = logic,
     parameter type          cr_chan_t     = logic,
     parameter type          cd_chan_t     = logic,
@@ -16,7 +15,7 @@ module ace_ccu_snoop_interconnect import ace_pkg::*; #(
     parameter type          snoop_resp_t  = logic,
 
     localparam type         oup_sel_t     = logic [NumOup-1:0],
-    localparam type         lup_addr_t    = logic [LupAddrWidth-1:0]
+    localparam type         cm_idx_t      = logic [CmIdxWidth-1:0]
 ) (
 
     input  logic                     clk_i,
@@ -28,12 +27,9 @@ module ace_ccu_snoop_interconnect import ace_pkg::*; #(
     output snoop_req_t  [NumOup-1:0] oup_req_o,
     input  snoop_resp_t [NumOup-1:0] oup_resp_i,
 
-    output logic                     lup_valid_o,
-    input  logic                     lup_ready_i,
-    output lup_addr_t                lup_addr_o,
-    input  logic                     lup_valid_i,
-    output logic                     lup_ready_o,
-    output logic                     lup_clr_o
+    output  logic                    cm_req_o,
+    output  cm_idx_t                 cm_addr_o,
+    input   logic                    cm_stall_i
 );
 
     typedef logic [$clog2(NumInp)-1:0] inp_idx_t;
@@ -241,21 +237,10 @@ module ace_ccu_snoop_interconnect import ace_pkg::*; #(
         .ctrl_o          (req_ctrl)
     );
 
-    if (ConfCheck) begin
-        assign oup_ac_valid = lup_valid_i;
-        assign lup_ready_o  = oup_ac_ready;
-        assign lup_valid_o  = ac_valid;
-        assign ac_ready     = lup_ready_i;
-        assign lup_addr_o   = ac_chan.addr[LupAddrBase+:LupAddrWidth];
-        assign lup_clr_o    = cr_valid && cr_ready;
-    end else begin
-        assign oup_ac_valid = ac_valid;
-        assign ac_ready     = oup_ac_ready;
-        assign lup_valid_o  = 1'b0;
-        assign lup_ready_o  = 1'b0;
-        assign lup_addr_o   = '0;
-        assign lup_clr_o    = 1'b0;
-    end
+    assign cm_req_o      = ac_valid && oup_ac_ready;
+    assign cm_addr_o     = ac_chan.addr[CmIdxBase+:CmIdxWidth];
+    assign ac_ready      = oup_ac_ready && !cm_stall_i;
+    assign oup_ac_valid  = ac_valid     && !cm_stall_i;
 
     stream_fifo_optimal_wrap #(
         .Depth  (2),

--- a/src/ccu/ace_ccu_top.sv
+++ b/src/ccu/ace_ccu_top.sv
@@ -11,8 +11,8 @@ module ace_ccu_top import ace_pkg::*;
   parameter int unsigned NoSlvPorts      = 0,
   parameter int unsigned NoSlvPerGroup   = 0,
   parameter int unsigned DcacheLineWidth = 0,
-  parameter int unsigned CmIdxBase       = $clog2(DcacheLineWidth >> 3),
-  parameter int unsigned CmIdxWidth      = 6,
+  parameter int unsigned CmAddrBase      = $clog2(DcacheLineWidth >> 3),
+  parameter int unsigned CmAddrWidth     = 8,
   parameter type slv_ar_chan_t           = logic,
   parameter type slv_aw_chan_t           = logic,
   parameter type slv_b_chan_t            = logic,
@@ -45,7 +45,7 @@ module ace_ccu_top import ace_pkg::*;
   input  mst_resp_t                    mst_resp_i
 );
 
-  typedef logic [CmIdxWidth-1:0] cm_idx_t;
+  typedef logic [CmAddrWidth-1:0] cm_idx_t;
 
   // Parameters to be used for testing/debugging
   // Otherwise assume they are hardcoded
@@ -64,7 +64,8 @@ module ace_ccu_top import ace_pkg::*;
   // Conflict management signals
   logic      [2*NoGroups-1:0] cm_x_req;
   cm_idx_t   [2*NoGroups-1:0] cm_x_addr;
-  logic                       cm_snoop_req;
+  logic                       cm_snoop_valid;
+  logic                       cm_snoop_ready;
   logic                       cm_snoop_stall;
   cm_idx_t                    cm_snoop_addr;
 
@@ -76,8 +77,8 @@ module ace_ccu_top import ace_pkg::*;
     .NoSlvPorts        (NoSlvPorts),
     .NoSlvPerGroup     (NoSlvPerGroup),
     .DcacheLineWidth   (DcacheLineWidth),
-    .CmIdxBase         (CmIdxBase),
-    .CmIdxWidth        (CmIdxWidth),
+    .CmAddrBase        (CmAddrBase),
+    .CmAddrWidth       (CmAddrWidth),
     .slv_ar_chan_t     (slv_ar_chan_t),
     .slv_aw_chan_t     (slv_aw_chan_t),
     .slv_b_chan_t      (slv_b_chan_t),
@@ -120,8 +121,8 @@ module ace_ccu_top import ace_pkg::*;
     .BufferInpResp(1),
     .BufferOupReq (1),
     .BufferOupResp(1),
-    .CmIdxBase    (CmIdxBase),
-    .CmIdxWidth   (CmIdxWidth),
+    .CmAddrBase   (CmAddrBase),
+    .CmAddrWidth  (CmAddrWidth),
     .ac_chan_t    (snoop_ac_t),
     .cr_chan_t    (snoop_cr_t),
     .cd_chan_t    (snoop_cd_t),
@@ -135,7 +136,8 @@ module ace_ccu_top import ace_pkg::*;
     .inp_resp_o        (snoop_resps),
     .oup_req_o         (snoop_req_o),
     .oup_resp_i        (snoop_resp_i),
-    .cm_req_o          (cm_snoop_req),
+    .cm_valid_o        (cm_snoop_valid),
+    .cm_ready_o        (cm_snoop_ready),
     .cm_addr_o         (cm_snoop_addr),
     .cm_stall_i        (cm_snoop_stall)
   );
@@ -145,12 +147,12 @@ module ace_ccu_top import ace_pkg::*;
     .NoRespPorts   (2*NoGroups),
     .MaxRespTrans  (8),
     .MaxSnoopTrans (8),
-    .CmIdxBase     (CmIdxBase),
-    .CmIdxWidth    (CmIdxWidth)
+    .CmAddrWidth   (CmAddrWidth)
   ) i_conflict_manager (
     .clk_i,
     .rst_ni,
-    .cm_snoop_req_i   (cm_snoop_req),
+    .cm_snoop_valid_i (cm_snoop_valid),
+    .cm_snoop_ready_i (cm_snoop_ready),
     .cm_snoop_addr_i  (cm_snoop_addr),
     .cm_snoop_stall_o (cm_snoop_stall),
     .cm_x_req_i       (cm_x_req),

--- a/src/ccu/ace_ccu_top.sv
+++ b/src/ccu/ace_ccu_top.sv
@@ -11,8 +11,8 @@ module ace_ccu_top import ace_pkg::*;
   parameter int unsigned NoSlvPorts      = 0,
   parameter int unsigned NoSlvPerGroup   = 0,
   parameter int unsigned DcacheLineWidth = 0,
-  parameter int unsigned LupAddrBase     = 0,
-  parameter int unsigned LupAddrWidth    = AxiAddrWidth,
+  parameter int unsigned CmIdxBase       = $clog2(DcacheLineWidth >> 3),
+  parameter int unsigned CmIdxWidth      = 6,
   parameter type slv_ar_chan_t           = logic,
   parameter type slv_aw_chan_t           = logic,
   parameter type slv_b_chan_t            = logic,
@@ -45,7 +45,7 @@ module ace_ccu_top import ace_pkg::*;
   input  mst_resp_t                    mst_resp_i
 );
 
-  typedef logic [LupAddrWidth-1:0] lup_addr_t;
+  typedef logic [CmIdxWidth-1:0] cm_idx_t;
 
   // Parameters to be used for testing/debugging
   // Otherwise assume they are hardcoded
@@ -62,19 +62,11 @@ module ace_ccu_top import ace_pkg::*;
   snoop_resp_t  [NoSnoopPorts-1:0] snoop_resps;
 
   // Conflict management signals
-  logic      [2*NoGroups-1:0] x_valids_in;
-  logic      [2*NoGroups-1:0] x_readies_out;
-  logic      [2*NoGroups-1:0] x_valids_out;
-  logic      [2*NoGroups-1:0] x_readies_in;
-  logic      [2*NoGroups-1:0] x_acks_out;
-  lup_addr_t [2*NoGroups-1:0] x_addr_out;
-  logic      [2*NoGroups-1:0] x_lasts_out;
-  logic                       snoop_valid_out;
-  logic                       snoop_ready_in;
-  logic                       snoop_clr_out;
-  logic                       snoop_valid_in;
-  logic                       snoop_ready_out;
-  lup_addr_t                  snoop_addr_out;
+  logic      [2*NoGroups-1:0] cm_x_req;
+  cm_idx_t   [2*NoGroups-1:0] cm_x_addr;
+  logic                       cm_snoop_req;
+  logic                       cm_snoop_stall;
+  cm_idx_t                    cm_snoop_addr;
 
   ace_ccu_master_path #(
     .AxiAddrWidth      (AxiAddrWidth),
@@ -84,9 +76,8 @@ module ace_ccu_top import ace_pkg::*;
     .NoSlvPorts        (NoSlvPorts),
     .NoSlvPerGroup     (NoSlvPerGroup),
     .DcacheLineWidth   (DcacheLineWidth),
-    .LupAddrBase       (LupAddrBase),
-    .LupAddrWidth      (LupAddrWidth),
-    .ConfCheck         (ConfCheck),
+    .CmIdxBase         (CmIdxBase),
+    .CmIdxWidth        (CmIdxWidth),
     .slv_ar_chan_t     (slv_ar_chan_t),
     .slv_aw_chan_t     (slv_aw_chan_t),
     .slv_b_chan_t      (slv_b_chan_t),
@@ -118,13 +109,8 @@ module ace_ccu_top import ace_pkg::*;
     .mst_resp_i        (mst_resp_i),
     .domain_set_i      (domain_set_i),
     .snoop_masks_o     (snoop_sel),
-    .x_valids_i        (x_valids_in),
-    .x_readies_o       (x_readies_out),
-    .x_valids_o        (x_valids_out),
-    .x_readies_i       (x_readies_in),
-    .x_acks_o          (x_acks_out),
-    .x_addr_o          (x_addr_out),
-    .x_lasts_o         (x_lasts_out)
+    .cm_req_o          (cm_x_req),
+    .cm_addr_o         (cm_x_addr)
   );
 
   ace_ccu_snoop_interconnect #(
@@ -134,9 +120,8 @@ module ace_ccu_top import ace_pkg::*;
     .BufferInpResp(1),
     .BufferOupReq (1),
     .BufferOupResp(1),
-    .ConfCheck    (ConfCheck),
-    .LupAddrBase  (LupAddrBase),
-    .LupAddrWidth (LupAddrWidth),
+    .CmIdxBase    (CmIdxBase),
+    .CmIdxWidth   (CmIdxWidth),
     .ac_chan_t    (snoop_ac_t),
     .cr_chan_t    (snoop_cr_t),
     .cd_chan_t    (snoop_cd_t),
@@ -150,42 +135,27 @@ module ace_ccu_top import ace_pkg::*;
     .inp_resp_o        (snoop_resps),
     .oup_req_o         (snoop_req_o),
     .oup_resp_i        (snoop_resp_i),
-    .lup_valid_o       (snoop_valid_out),
-    .lup_ready_i       (snoop_ready_in),
-    .lup_addr_o        (snoop_addr_out),
-    .lup_valid_i       (snoop_valid_in),
-    .lup_ready_o       (snoop_ready_out),
-    .lup_clr_o         (snoop_clr_out)
+    .cm_req_o          (cm_snoop_req),
+    .cm_addr_o         (cm_snoop_addr),
+    .cm_stall_i        (cm_snoop_stall)
   );
 
-  if (ConfCheck) begin : gen_conf_mng
-
-    ace_ccu_conflict_manager #(
-      .AxiAddrWidth  (AxiAddrWidth),
-      .NoRespPorts   (2*NoGroups),
-      .MaxRespTrans  (8),
-      .MaxSnoopTrans (8),
-      .LupAddrBase   (LupAddrBase),
-      .LupAddrWidth  (LupAddrWidth)
-    ) i_conflict_manager (
-      .clk_i,
-      .rst_ni,
-      .x_valid_i     (x_valids_out),
-      .x_ready_o     (x_readies_in),
-      .x_addr_i      (x_addr_out),
-      .x_valid_o     (x_valids_in),
-      .x_ready_i     (x_readies_out),
-      .x_ack_i       (x_acks_out),
-      .x_lasts_i     (x_lasts_out),
-      .snoop_valid_i (snoop_valid_out),
-      .snoop_ready_o (snoop_ready_in),
-      .snoop_clr_i   (snoop_clr_out),
-      .snoop_addr_i  (snoop_addr_out),
-      .snoop_valid_o (snoop_valid_in),
-      .snoop_ready_i (snoop_ready_out)
-    );
-
-  end
+  ace_ccu_conflict_manager #(
+    .AxiAddrWidth  (AxiAddrWidth),
+    .NoRespPorts   (2*NoGroups),
+    .MaxRespTrans  (8),
+    .MaxSnoopTrans (8),
+    .CmIdxBase     (CmIdxBase),
+    .CmIdxWidth    (CmIdxWidth)
+  ) i_conflict_manager (
+    .clk_i,
+    .rst_ni,
+    .cm_snoop_req_i   (cm_snoop_req),
+    .cm_snoop_addr_i  (cm_snoop_addr),
+    .cm_snoop_stall_o (cm_snoop_stall),
+    .cm_x_req_i       (cm_x_req),
+    .cm_x_addr_i      (cm_x_addr)
+  );
 
 endmodule
 


### PR DESCRIPTION
Add stronger constraints on transaction ordering through an associative structure to store identifiers for cache lines targeted by inflight transactions.