### PR TITLE
Add memory unit

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -32,7 +32,7 @@ sources:
   - src/ccu/ace_ccu_lock_reg.sv
   - src/ccu/ccu_ctrl_wr_snoop.sv
   - src/ccu/ccu_ctrl_r_snoop.sv
-  - src/ccu/ccu_ctrl_mem.sv
+  - src/ccu/ccu_mem_ctrl.sv
   - src/ccu/ace_ccu_snoop_path.sv
   - src/ccu/ace_ccu_snoop_resp.sv
   - src/ccu/ace_ccu_snoop_req.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -32,6 +32,7 @@ sources:
   - src/ccu/ace_ccu_lock_reg.sv
   - src/ccu/ccu_ctrl_wr_snoop.sv
   - src/ccu/ccu_ctrl_r_snoop.sv
+  - src/ccu/ccu_ctrl_mem.sv
   - src/ccu/ace_ccu_snoop_path.sv
   - src/ccu/ace_ccu_snoop_resp.sv
   - src/ccu/ace_ccu_snoop_req.sv

--- a/src/ccu/ace_ccu_master_path.sv
+++ b/src/ccu/ace_ccu_master_path.sv
@@ -4,6 +4,7 @@
 
 module ace_ccu_master_path import ace_pkg::*;
 #(
+  parameter bit          LEGACY          = 0,
   parameter int unsigned AxiAddrWidth    = 0,
   parameter int unsigned AxiDataWidth    = 0,
   parameter int unsigned AxiUserWidth    = 0,
@@ -108,6 +109,7 @@ module ace_ccu_master_path import ace_pkg::*;
     );
 
     ace_ar_transaction_decoder #(
+        .LEGACY    (LEGACY),
         .ar_chan_t (slv_ar_chan_t)
     ) i_read_decoder (
         .ar_i          (slv_req_i[i].ar),
@@ -363,6 +365,7 @@ module ace_ccu_master_path import ace_pkg::*;
     ////////////////
 
     ace_ccu_snoop_path #(
+      .LEGACY          (LEGACY),
       .NoRules         (NoSlvPerGroup),
       .DcacheLineWidth (DcacheLineWidth),
       .AxiDataWidth    (AxiDataWidth),

--- a/src/ccu/ace_ccu_master_path.sv
+++ b/src/ccu/ace_ccu_master_path.sv
@@ -376,7 +376,6 @@ module ace_ccu_master_path import ace_pkg::*;
       .ace_ar_chan_t   (int_ace_ar_chan_t),
       .ace_req_t       (int_ace_req_t),
       .ace_resp_t      (int_ace_resp_t),
-      .axi_aw_chan_t   (int_axi_aw_chan_t),
       .w_chan_t        (w_chan_t),
       .axi_req_t       (int_axi_req_t),
       .axi_resp_t      (int_axi_resp_t),

--- a/src/ccu/ace_ccu_master_path.sv
+++ b/src/ccu/ace_ccu_master_path.sv
@@ -80,8 +80,8 @@ module ace_ccu_master_path import ace_pkg::*;
   `AXI_TYPEDEF_REQ_T    (int_axi_req_t, int_axi_aw_chan_t, w_chan_t, int_axi_ar_chan_t)
   `AXI_TYPEDEF_RESP_T   (int_axi_resp_t, int_axi_b_chan_t, int_axi_r_chan_t)
 
-  // Three ports per group: non snooping, write snooping, read snooping
-  localparam NoMemPortsPerGroup = 3;
+  // Two ports per group: non snooping, snooping
+  localparam NoMemPortsPerGroup = 2;
   localparam NoMemPorts         = NoMemPortsPerGroup*NoGroups;
   int_axi_req_t  [NoMemPorts-1:0] axi_memory_reqs;
   int_axi_resp_t [NoMemPorts-1:0] axi_memory_resps;
@@ -363,13 +363,14 @@ module ace_ccu_master_path import ace_pkg::*;
       .DcacheLineWidth (DcacheLineWidth),
       .AxiDataWidth    (AxiDataWidth),
       .AxiSlvIdWidth   (AxiSlvIdWidth),
-      .aw_chan_t       (int_ace_aw_chan_t),
-      .w_chan_t        (w_chan_t),
-      .b_chan_t        (int_ace_b_chan_t),
-      .ar_chan_t       (int_ace_ar_chan_t),
-      .r_chan_t        (int_ace_r_chan_t),
-      .req_t           (int_ace_req_t),
-      .resp_t          (int_ace_resp_t),
+      .ace_aw_chan_t   (int_ace_aw_chan_t),
+      .ace_ar_chan_t   (int_ace_ar_chan_t),
+      .ace_req_t       (int_ace_req_t),
+      .ace_resp_t      (int_ace_resp_t),
+      .axi_aw_chan_t   (int_axi_aw_chan_t),
+      .axi_w_chan_t    (w_chan_t),
+      .axi_req_t       (int_axi_req_t),
+      .axi_resp_t      (int_axi_resp_t),
       .snoop_ac_t      (snoop_ac_t),
       .snoop_cr_t      (snoop_cr_t),
       .snoop_cd_t      (snoop_cd_t),
@@ -382,18 +383,18 @@ module ace_ccu_master_path import ace_pkg::*;
       .rst_ni         (rst_ni),
       .slv_req_i      (ace_snooping_forked_req),
       .slv_resp_o     (ace_snooping_forked_resp),
-      .mst_reqs_o     (ace_memory_reqs),
-      .mst_resps_i    (ace_memory_resps),
-      .domain_set_i   (domain_set_i   [(NoSlvPerGroup*i)+:NoSlvPerGroup]),
-      .snoop_reqs_o   (snoop_req_o    [(2*i)+:2]),
-      .snoop_resps_i  (snoop_resp_i   [(2*i)+:2]),
-      .snoop_masks_o  (snoop_masks_o  [(2*i)+:2])
+      .mst_req_o      (axi_memory_reqs [i*NoMemPortsPerGroup+1]),
+      .mst_resp_i     (axi_memory_resps[i*NoMemPortsPerGroup+1]),
+      .domain_set_i   (domain_set_i    [(NoSlvPerGroup*i)+:NoSlvPerGroup]),
+      .snoop_reqs_o   (snoop_req_o     [(2*i)+:2]),
+      .snoop_resps_i  (snoop_resp_i    [(2*i)+:2]),
+      .snoop_masks_o  (snoop_masks_o   [(2*i)+:2])
     );
 
-    for (genvar j = 1; j < NoMemPortsPerGroup; j++) begin : gen_ace_to_axi
-      `ACE_TO_AXI_ASSIGN_REQ(axi_memory_reqs[NoMemPortsPerGroup*i+j], ace_memory_reqs[j-1])
-      `AXI_TO_ACE_ASSIGN_RESP(ace_memory_resps[j-1], axi_memory_resps[NoMemPortsPerGroup*i+j])
-    end
+    //for (genvar j = 1; j < NoMemPortsPerGroup; j++) begin : gen_ace_to_axi
+    //  `ACE_TO_AXI_ASSIGN_REQ(axi_memory_reqs[NoMemPortsPerGroup*i+j], ace_memory_reqs[j-1])
+    //  `AXI_TO_ACE_ASSIGN_RESP(ace_memory_resps[j-1], axi_memory_resps[NoMemPortsPerGroup*i+j])
+    //end
   end
 
   //////////////////
@@ -450,16 +451,16 @@ module ace_ccu_master_path import ace_pkg::*;
   axi_mux #(
     .SlvAxiIDWidth (AxiIntIdWidth),
     .slv_aw_chan_t (int_axi_aw_chan_t),
-    .mst_aw_chan_t (mst_aw_chan_t),
-    .w_chan_t      (w_chan_t),
     .slv_b_chan_t  (int_axi_b_chan_t),
-    .mst_b_chan_t  (mst_b_chan_t),
     .slv_ar_chan_t (int_axi_ar_chan_t),
-    .mst_ar_chan_t (mst_ar_chan_t),
-    .slv_r_chan_t  (int_axi_r_chan_t),
-    .mst_r_chan_t  (mst_r_chan_t),
     .slv_req_t     (int_axi_req_t),
     .slv_resp_t    (int_axi_resp_t),
+    .slv_r_chan_t  (int_axi_r_chan_t),
+    .mst_aw_chan_t (mst_aw_chan_t),
+    .w_chan_t      (w_chan_t),
+    .mst_b_chan_t  (mst_b_chan_t),
+    .mst_ar_chan_t (mst_ar_chan_t),
+    .mst_r_chan_t  (mst_r_chan_t),
     .mst_req_t     (mst_req_t),
     .mst_resp_t    (mst_resp_t),
     .NoSlvPorts    (NoMemPorts),

--- a/src/ccu/ace_ccu_snoop_path.sv
+++ b/src/ccu/ace_ccu_snoop_path.sv
@@ -25,14 +25,15 @@ module ace_ccu_snoop_path import ace_pkg::*; import ccu_pkg::*; #(
     input  logic                       rst_ni,
     input  req_t                       slv_req_i,
     output resp_t                      slv_resp_o,
-    output req_t         [1:0]         mst_reqs_o,
-    input  resp_t        [1:0]         mst_resps_i,
+    output req_t                       mst_req_o,
+    input  resp_t                      mst_resp_i,
     input  domain_set_t  [NoRules-1:0] domain_set_i,
     output snoop_req_t   [1:0]         snoop_reqs_o,
     input  snoop_resp_t  [1:0]         snoop_resps_i,
     output domain_mask_t [1:0]         snoop_masks_o
 );
-
+    req_t  [1:0] mst_reqs;
+    resp_t [1:0] mst_resps;
     localparam RuleIdBits = $clog2(NoRules);
     typedef logic [RuleIdBits-1:0] rule_idx_t;
 
@@ -100,8 +101,8 @@ module ace_ccu_snoop_path import ace_pkg::*; import ccu_pkg::*; #(
         .slv_req_i     (slv_write_req),
         .slv_resp_o    (slv_write_resp),
         .snoop_trs_i   (write_acsnoop),
-        .mst_req_o     (mst_reqs_o     [0]),
-        .mst_resp_i    (mst_resps_i    [0]),
+        .mst_req_o     (mst_reqs       [0]),
+        .mst_resp_i    (mst_resps      [0]),
         .snoop_req_o   (snoop_reqs_o   [0]),
         .snoop_resp_i  (snoop_resps_i  [0]),
         .domain_set_i  (domain_set_i[write_rule_idx]),
@@ -148,12 +149,29 @@ module ace_ccu_snoop_path import ace_pkg::*; import ccu_pkg::*; #(
         .slv_req_i     (slv_read_req),
         .slv_resp_o    (slv_read_resp),
         .snoop_info_i  (read_snoop_info),
-        .mst_req_o     (mst_reqs_o     [1]),
-        .mst_resp_i    (mst_resps_i    [1]),
+        .mst_req_o     (mst_reqs       [1]),
+        .mst_resp_i    (mst_resps      [1]),
         .snoop_req_o   (snoop_reqs_o   [1]),
         .snoop_resp_i  (snoop_resps_i  [1]),
         .domain_set_i  (domain_set_i[read_rule_idx]),
         .domain_mask_o (snoop_masks_o  [1])
     );
+
+    ccu_mem_ctrl #(
+        .AxiIdWidth (),
+        .slv_req_t (req_t),
+        .slv_resp_t (resp_t),
+        .mst_req_t (),
+        .mst_resp_t ()
+    ) i_ccu_mem_ctrl (
+        .clk_i,
+        .rst_ni,
+        .wr_mst_req_i (mst_reqs[1]),
+        .wr_mst_resp_o (mst_resps[1]),
+        .r_mst_req_i (mst_reqs[0]),
+        .r_mst_resp_o (mst_resps[0]),
+        .mst_req_o,
+        .mst_resp_i
+    )
 
 endmodule

--- a/src/ccu/ace_ccu_snoop_path.sv
+++ b/src/ccu/ace_ccu_snoop_path.sv
@@ -2,21 +2,20 @@
 `include "ace/assign.svh"
 
 module ace_ccu_snoop_path import ace_pkg::*; import ccu_pkg::*; #(
-    parameter bit          LEGACY          = 0,
+    parameter bit          LEGACY          = 0,     // Support legacy WB cache
     parameter int unsigned NoRules         = 0,
     parameter int unsigned DcacheLineWidth = 0,
     parameter int unsigned AxiDataWidth    = 0,
     parameter int unsigned AxiSlvIdWidth   = 0,
     parameter int unsigned AxiAddrWidth    = 0,
     parameter int unsigned AxiUserWidth    = 0,
-    parameter type ace_aw_chan_t           = logic, // AW Channel Type
-    parameter type ace_ar_chan_t           = logic, // AR Channel Type
-    parameter type ace_req_t               = logic, // Request type, without FSM route bits
-    parameter type ace_resp_t              = logic, // Response type, without FSM route bits
-    parameter type axi_aw_chan_t           = logic, // AW Channel Type
+    parameter type ace_aw_chan_t           = logic, // AW Channel Type, ACE, without FSM route bits
+    parameter type ace_ar_chan_t           = logic, // AR Channel Type, ACE, without FSM route bits
+    parameter type ace_req_t               = logic, // Request type, ACE, without FSM route bits
+    parameter type ace_resp_t              = logic, // Response type, ACE, without FSM route bits
     parameter type w_chan_t                = logic, // W Channel Type
-    parameter type axi_req_t               = logic, // Request type, with FSM route bits
-    parameter type axi_resp_t              = logic, // Response type, with FSM route bits
+    parameter type axi_req_t               = logic, // Request type, AXI, with FSM route bits
+    parameter type axi_resp_t              = logic, // Response type, AXI, with FSM route bits
     parameter type snoop_ac_t              = logic, // AC channel, snoop port
     parameter type snoop_cr_t              = logic, // CR channel, snoop port
     parameter type snoop_cd_t              = logic, // CD channel, snoop port

--- a/src/ccu/ace_ccu_snoop_path.sv
+++ b/src/ccu/ace_ccu_snoop_path.sv
@@ -2,6 +2,7 @@
 `include "ace/assign.svh"
 
 module ace_ccu_snoop_path import ace_pkg::*; import ccu_pkg::*; #(
+    parameter bit          LEGACY          = 0,
     parameter int unsigned NoRules         = 0,
     parameter int unsigned DcacheLineWidth = 0,
     parameter int unsigned AxiDataWidth    = 0,
@@ -142,6 +143,7 @@ module ace_ccu_snoop_path import ace_pkg::*; import ccu_pkg::*; #(
         assign read_rule_idx = slv_read_req.ar.id[AxiSlvIdWidth+:RuleIdBits];
 
     ace_ar_transaction_decoder #(
+        .LEGACY    (LEGACY),
         .ar_chan_t (ace_ar_chan_t)
     ) i_read_decoder (
         .ar_i          (slv_read_req.ar),

--- a/src/ccu/ace_ccu_top.sv
+++ b/src/ccu/ace_ccu_top.sv
@@ -4,6 +4,7 @@
 
 module ace_ccu_top import ace_pkg::*;
 #(
+  parameter bit          LEGACY          = 0,
   parameter int unsigned AxiAddrWidth    = 0,
   parameter int unsigned AxiDataWidth    = 0,
   parameter int unsigned AxiUserWidth    = 0,
@@ -70,6 +71,7 @@ module ace_ccu_top import ace_pkg::*;
   cm_idx_t                    cm_snoop_addr;
 
   ace_ccu_master_path #(
+    .LEGACY            (LEGACY),
     .AxiAddrWidth      (AxiAddrWidth),
     .AxiDataWidth      (AxiDataWidth),
     .AxiUserWidth      (AxiUserWidth),
@@ -162,6 +164,7 @@ module ace_ccu_top import ace_pkg::*;
 endmodule
 
 module ace_ccu_top_intf #(
+  parameter bit          LEGACY            = 0,
   parameter int unsigned AXI_ADDR_WIDTH    = 0,
   parameter int unsigned AXI_DATA_WIDTH    = 0,
   parameter int unsigned AXI_USER_WIDTH    = 0,
@@ -234,6 +237,7 @@ module ace_ccu_top_intf #(
   `AXI_ASSIGN_TO_RESP(mst_resp, mst_port)
 
   ace_ccu_top #(
+    .LEGACY          (LEGACY           ),
     .AxiAddrWidth    (AXI_ADDR_WIDTH   ),
     .AxiDataWidth    (AXI_DATA_WIDTH   ),
     .AxiUserWidth    (AXI_USER_WIDTH   ),

--- a/src/ccu/ace_ccu_top.sv
+++ b/src/ccu/ace_ccu_top.sv
@@ -183,7 +183,7 @@ module ace_ccu_top_intf #(
   localparam NO_GROUPS = NO_SLV_PORTS/NO_SLV_PER_GROUPS;
   localparam AXI_ID_MST_WIDTH = AXI_SLV_ID_WIDTH          + // Initial ID width
                                 $clog2(NO_SLV_PER_GROUPS) + // Internal MUX additional bits
-                                $clog2(3*NO_GROUPS);        // Final MUX additional bits
+                                $clog2(3*NO_GROUPS) + 1;    // Final MUX additional bits
 
   typedef logic [AXI_SLV_ID_WIDTH-1:0] id_slv_t;
   typedef logic [AXI_ID_MST_WIDTH-1:0] id_mst_t;

--- a/src/ccu/ccu_ctrl_mem.sv
+++ b/src/ccu/ccu_ctrl_mem.sv
@@ -1,0 +1,142 @@
+module ccu_mem_ctrl import ace_pkg::*; #(
+    parameter int unsigned AxiIdWidth = 0,
+    parameter type slv_req_t = logic,
+    parameter type slv_resp_t = logic,
+    parameter type mst_req_t = logic,
+    parameter type mst_resp_t = logic
+)(
+    input clk_i,
+    input rst_ni,
+    input slv_req_t wr_mst_req_i,
+    output slv_resp_t wr_mst_resp_o,
+    input slv_req_t r_mst_req_i,
+    output slv_resp_t r_mst_resp_o,
+    output mst_req_t mst_req_o,
+    input mst_resp_t mst_resp_i
+);
+
+logic w_select, w_fifo_push, w_fifo_pop, w_fifo_empty, w_fifo_full;
+logic w_select_fifo;
+logic w_valid, w_ready;
+logic aw_lock_d, aw_lock_q;
+mst_req_t mst_req;
+
+always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (~rst_ni) begin
+        aw_lock_q <= 1'b0;
+    end else begin
+        aw_lock_q <= aw_lock_d;
+    end
+end
+
+// Index 0 - W FSM
+// Index 1 - R FSM
+
+// AW Channel
+stream_arbiter #(
+    .DATA_T(axi_aw_chan_t),
+    .N_INP (2)
+) i_stream_arbiter_aw (
+    .clk_i,
+    .rst_ni,
+    .inp_data_i ({r_mst_req_i.aw, wr_mst_req_i.aw}),
+    .inp_valid_i({r_mst_req_i.aw_valid, wr_mst_req_i.aw_valid}),
+    .inp_ready_o({r_mst_resp_o.aw_ready, wr_mst_resp_o.aw_ready}),
+    .oup_data_o (mst_req.aw),
+    .oup_valid_o(mst_req.aw_valid),
+    .oup_ready_i(mst_resp_i.aw_ready)
+);
+
+// AR Channel (W-FSM cannot generate AR requests)
+assign mst_req.ar            = r_mst_req_i.ar;
+assign mst_req.ar_valid      = r_mst_req_i.ar_valid;
+assign r_mst_resp_o.ar_ready = mst_resp_i.ar_ready;
+
+// ID Prepending
+// Ensure that restrictive accesses get the same ID
+always_comb begin
+    mst_req_o = mst_req;
+    if (mst_req.aw.lock) begin
+        mst_req_o.aw.id = {2'b00, mst_req.aw.id};
+    end else begin
+        mst_req_o.aw.id = {!w_select, w_select, mst_req.aw.id};
+    end
+    if (mst_req.ar.lock) begin
+        mst_req_o.ar.id = {2'b00, mst_req.ar.id};
+    end else begin
+        mst_req_o.ar.id = {2'b01, mst_req.ar.id};
+    end
+end
+
+// W Channel
+stream_mux #(
+    .DATA_T(axi_w_chan_t),
+    .N_INP (2)
+) i_stream_mux_w (
+    .inp_data_i ({r_mst_req_i.w, wr_mst_req_i.w}),
+    .inp_valid_i({r_mst_req_i.w_valid, wr_mst_req_i.w_valid}),
+    .inp_ready_o({r_mst_resp_o.w_ready, wr_mst_resp_o.w_ready}),
+    .inp_sel_i  (w_select_fifo),
+    .oup_data_o (mst_req_o.w),
+    .oup_valid_o(w_valid),
+    .oup_ready_i(w_ready)
+);
+
+// W index
+fifo_v3 #(
+    .FALL_THROUGH   (1'b1),
+    .DEPTH          (2)
+) i_w_cmd_fifo (
+    .clk_i      (clk_i),
+    .rst_ni     (rst_ni),
+    .flush_i    (1'b0),
+    .testmode_i (1'b0),
+    .full_o     (w_fifo_full),
+    .empty_o    (),
+    .usage_o    (),
+    .data_i     (w_select),
+    .push_i     (w_fifo_push),
+    .data_o     (w_select_fifo),
+    .pop_i      (w_fifo_pop)
+);
+
+assign w_select    = r_mst_req_i.aw_valid && r_mst_resp_o.aw_ready;
+assign w_fifo_push = ~aw_lock_q && mst_req_o.aw_valid;
+assign w_fifo_pop  = mst_req_o.w_valid && mst_resp_i.w_ready && mst_req_o.w.last;
+assign aw_lock_d   = ~mst_resp_i.aw_ready && (mst_req_o.aw_valid || aw_lock_q);
+
+assign w_fifo_empty = w_fifo_usage == 0 && !w_fifo_full;
+
+// Block handshake if fifo empty
+assign mst_req_o.w_valid = w_valid            && !w_fifo_empty;
+assign w_ready           = mst_resp_i.w_ready && !w_fifo_empty;
+
+// B Channel
+assign r_mst_resp_o.b  = mst_resp_i.b;
+assign wr_mst_resp_o.b = mst_resp_i.b;
+always_comb begin
+    if (mst_resp_i.b.id[AxiIdWidth+1:AxiIdWidth] == 2'b01) begin
+        r_mst_resp_o.b_valid = mst_resp_i.b_valid;
+        mst_req_o.b_ready    = r_mst_req_i.b_ready;
+    end
+    else begin
+        w_mst_resp_o.b_valid = mst_resp_i.b_valid
+        mst_req_o.b_ready    = w_mst_resp_o.b_ready;
+    end
+end
+
+// R Channel
+assign r_mst_resp_o.r  = mst_resp_i.r;
+assign wr_mst_resp_o.r = mst_resp_i.r;
+always_comb begin
+    if (mst_resp_i.r.id[AxiIdWidth+1:AxiIdWidth] == 2'b10) begin
+        wr_mst_resp_o.r_valid = mst_resp_i.r_valid;
+        mst_req_o.r_ready     = wr_mst_req_i.r_ready;
+    end
+    else begin
+        r_mst_resp_o.r_valid = mst_resp_i.r_valid;
+        mst_req_o.r_ready    = r_mst_req_i.r_ready;
+    end
+end
+
+endmodule

--- a/src/ccu/ccu_ctrl_r_snoop.sv
+++ b/src/ccu/ccu_ctrl_r_snoop.sv
@@ -159,7 +159,7 @@ always_comb begin
     mst_req_o.aw.prot     = slv_req_holder.ar.prot;
     mst_req_o.aw.qos      = slv_req_holder.ar.qos;
     mst_req_o.aw.region   = slv_req_holder.ar.region;
-    mst_req_o.aw.atop     = '0; // TODO
+    mst_req_o.aw.atop     = '0;
     mst_req_o.aw.user     = slv_req_holder.ar.user;
 
     mst_req_o.w.data  = snoop_resp_i.cd.data;

--- a/src/ccu/ccu_ctrl_wr_snoop.sv
+++ b/src/ccu/ccu_ctrl_wr_snoop.sv
@@ -119,8 +119,6 @@ always_comb begin
     mst_req_o.ar        = '0;
     mst_req_o.ar_valid  = 1'b0;
     mst_req_o.r_ready   = 1'b0;
-    mst_req_o.rack      = 1'b0;
-    mst_req_o.wack      = 1'b0;
 end
 
 // Write channel

--- a/src/ccu/ccu_ctrl_wr_snoop.sv
+++ b/src/ccu/ccu_ctrl_wr_snoop.sv
@@ -1,3 +1,4 @@
+`include "axi/assign.svh"
 import ace_pkg::*;
 
 // FSM to control write snoop transactions
@@ -124,10 +125,13 @@ end
 // Write channel
 always_comb begin
     slv_resp_o.b       = mst_resp_i.b;
-    mst_req_o.aw       = slv_req_holder.aw;
+    `AXI_SET_AW_STRUCT(mst_req_o.aw, slv_req_holder.aw)
     mst_req_o.aw_valid = aw_valid_q;
     if (write_back_source) begin
-        mst_req_o.w = slv_req_i.w;
+        mst_req_o.w.data = slv_req_i.w.data;
+        mst_req_o.w.strb = slv_req_i.w.strb;
+        mst_req_o.w.last = slv_req_i.w.last;
+        mst_req_o.w.user = slv_req_i.w.user;
     end else begin
         mst_req_o.aw.burst = axi_pkg::BURST_WRAP;
         mst_req_o.aw.len   = AXLEN;

--- a/src/ccu/ccu_mem_ctrl.sv
+++ b/src/ccu/ccu_mem_ctrl.sv
@@ -1,28 +1,31 @@
+`include "axi/assign.svh"
 module ccu_mem_ctrl import ace_pkg::*; #(
-    parameter int unsigned AxiIdWidth = 0,
-    parameter type req_t = logic,
-    parameter type resp_t = logic,
+    parameter type slv_req_t = logic,
+    parameter type slv_resp_t = logic,
+    parameter type mst_req_t = logic,
+    parameter type mst_resp_t = logic,
     parameter type aw_chan_t = logic,
     parameter type w_chan_t = logic
 )(
     input clk_i,
     input rst_ni,
-    input req_t wr_mst_req_i,
-    output resp_t wr_mst_resp_o,
-    input req_t r_mst_req_i,
-    output resp_t r_mst_resp_o,
-    output req_t mst_req_o,
-    input resp_t mst_resp_i
+    input slv_req_t wr_mst_req_i,
+    output slv_resp_t wr_mst_resp_o,
+    input slv_req_t r_mst_req_i,
+    output slv_resp_t r_mst_resp_o,
+    output mst_req_t mst_req_o,
+    input mst_resp_t mst_resp_i
 );
 
 localparam int unsigned FIFO_DEPTH = 4;
+parameter int unsigned SlvAxiIdWidth = $bits(r_mst_req_i.aw.id); // ID width in slv_req_t
 
 logic w_select, w_fifo_push, w_fifo_pop, w_fifo_empty, w_fifo_full;
 logic w_select_fifo;
 logic [$clog2(FIFO_DEPTH)-1:0] w_fifo_usage;
 logic w_valid, w_ready;
 logic aw_lock_d, aw_lock_q;
-req_t mst_req;
+slv_req_t mst_req;
 
 always_ff @(posedge clk_i or negedge rst_ni) begin
     if (~rst_ni) begin
@@ -51,24 +54,27 @@ stream_arbiter #(
 );
 
 // AR Channel (W-FSM cannot generate AR requests)
-assign mst_req.ar            = r_mst_req_i.ar;
-assign mst_req.ar_valid      = r_mst_req_i.ar_valid;
-assign r_mst_resp_o.ar_ready = mst_resp_i.ar_ready;
+assign mst_req.ar             = r_mst_req_i.ar;
+assign mst_req.ar_valid       = r_mst_req_i.ar_valid;
+assign r_mst_resp_o.ar_ready  = mst_resp_i.ar_ready;
+assign wr_mst_resp_o.ar_ready = 1'b0;
 
 // ID Prepending
 // Ensure that restrictive accesses get the same ID
 always_comb begin
-    mst_req_o.aw = mst_req.aw;
-    mst_req_o.ar = mst_req.ar;
+    mst_req_o.aw_valid = mst_req.aw_valid;
+    mst_req_o.ar_valid = mst_req.ar_valid;
+    `AXI_SET_AW_STRUCT(mst_req_o.aw, mst_req.aw)
+    `AXI_SET_AR_STRUCT(mst_req_o.ar, mst_req.ar)
     if (mst_req.aw.lock) begin
-        mst_req_o.aw.id = {2'b00, mst_req.aw.id[AxiIdWidth-1:0]};
+        mst_req_o.aw.id = {2'b00, mst_req.aw.id[SlvAxiIdWidth-1:0]};
     end else begin
-        mst_req_o.aw.id = {!w_select, w_select, mst_req.aw.id[AxiIdWidth-1:0]};
+        mst_req_o.aw.id = {!w_select, w_select, mst_req.aw.id[SlvAxiIdWidth-1:0]};
     end
     if (mst_req.ar.lock) begin
-        mst_req_o.ar.id = {2'b00, mst_req.ar.id[AxiIdWidth-1:0]};
+        mst_req_o.ar.id = {2'b00, mst_req.ar.id[SlvAxiIdWidth-1:0]};
     end else begin
-        mst_req_o.ar.id = {2'b01, mst_req.ar.id[AxiIdWidth-1:0]};
+        mst_req_o.ar.id = {2'b01, mst_req.ar.id[SlvAxiIdWidth-1:0]};
     end
 end
 
@@ -81,7 +87,7 @@ stream_mux #(
     .inp_valid_i({r_mst_req_i.w_valid, wr_mst_req_i.w_valid}),
     .inp_ready_o({r_mst_resp_o.w_ready, wr_mst_resp_o.w_ready}),
     .inp_sel_i  (w_select_fifo),
-    .oup_data_o (mst_req_o.w),
+    .oup_data_o (mst_req.w),
     .oup_valid_o(w_valid),
     .oup_ready_i(w_ready)
 );
@@ -113,6 +119,7 @@ assign aw_lock_d   = ~mst_resp_i.aw_ready && (mst_req_o.aw_valid || aw_lock_q);
 assign w_fifo_empty = w_fifo_usage == 0 && !w_fifo_full;
 
 // Block handshake if fifo empty
+`AXI_ASSIGN_W_STRUCT(mst_req_o.w, mst_req.w)
 assign mst_req_o.w_valid = w_valid            && !w_fifo_empty;
 assign w_ready           = mst_resp_i.w_ready && !w_fifo_empty;
 
@@ -120,7 +127,9 @@ assign w_ready           = mst_resp_i.w_ready && !w_fifo_empty;
 assign r_mst_resp_o.b  = mst_resp_i.b;
 assign wr_mst_resp_o.b = mst_resp_i.b;
 always_comb begin
-    if (mst_resp_i.b.id[AxiIdWidth+1:AxiIdWidth] == 2'b01) begin
+    r_mst_resp_o.b_valid  = 1'b0;
+    wr_mst_resp_o.b_valid = 1'b0;
+    if (mst_resp_i.b.id[SlvAxiIdWidth+1:SlvAxiIdWidth] == 2'b01) begin
         r_mst_resp_o.b_valid = mst_resp_i.b_valid;
         mst_req_o.b_ready    = r_mst_req_i.b_ready;
     end
@@ -134,7 +143,9 @@ end
 assign r_mst_resp_o.r  = mst_resp_i.r;
 assign wr_mst_resp_o.r = mst_resp_i.r;
 always_comb begin
-    if (mst_resp_i.r.id[AxiIdWidth+1:AxiIdWidth] == 2'b10) begin
+    wr_mst_resp_o.r_valid = 1'b0;
+    r_mst_resp_o.r_valid  = 1'b0;
+    if (mst_resp_i.r.id[SlvAxiIdWidth+1:SlvAxiIdWidth] == 2'b10) begin
         wr_mst_resp_o.r_valid = mst_resp_i.r_valid;
         mst_req_o.r_ready     = wr_mst_req_i.r_ready;
     end
@@ -143,5 +154,16 @@ always_comb begin
         mst_req_o.r_ready    = r_mst_req_i.r_ready;
     end
 end
+
+// pragma translate_off
+`ifndef VERILATOR
+initial begin : p_assert
+    assert(($bits(mst_req_o.aw.id) - $bits(r_mst_req_i.aw.id)) == 2)
+        else $fatal(1, "Difference in AW ID widths should be 2");
+    assert(($bits(mst_req_o.ar.id) - $bits(r_mst_req_i.ar.id)) == 2)
+        else $fatal(1, "Difference in AR ID widths should be 2");
+end
+`endif
+// pragma translate_on
 
 endmodule

--- a/test/tb_ace_ccu_top.sv
+++ b/test/tb_ace_ccu_top.sv
@@ -41,7 +41,8 @@ module tb_ace_ccu_top #(
     localparam int unsigned AxiIdUsed         =  3;
     localparam int unsigned AxiIdWidthSlave   =  AxiIdWidthMasters
                                                  + $clog2(MstPerGroup)
-                                                 + $clog2(3*NoGroups);
+                                                 + $clog2(3*NoGroups)
+                                                 + 1; // R/W FSM encoding
     localparam int unsigned AxiAddrWidth      =  AddrWidth;
     localparam int unsigned AxiDataWidth      =  DataWidth;
     localparam int unsigned AxiStrbWidth      =  AxiDataWidth / 8;
@@ -310,6 +311,7 @@ module tb_ace_ccu_top #(
         .DCACHE_LINE_WIDTH    (CachelineBits),
         .domain_mask_t        (domain_mask_t),
         .domain_set_t         (domain_set_t)
+        //.LEGACY(1)
     ) ccu (
         .clk_i                (clk),
         .rst_ni               (rst_n),


### PR DESCRIPTION
Memory unit for arbitrating the memory port between Write and Read FSMs.

Tricky part was ensuring that ARLOCK and AWLOCK transactions use the same ID. Also, ATOPs require that R response is routed to Write FSM. Thus, it was needed to use 2 extra ID bits to encode this information.

The total number of ID bits was increased by 1.